### PR TITLE
Mark the mod as client-side only

### DIFF
--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -6,11 +6,7 @@
   "description": "Makes gameplay more satisfying through the use of various camera tilting. Compatible with everything.\nConfigurable through '.minecraft/config/cameraoverhaul.json'.",
   "license": "MIT",
   "icon": "assets/cameraoverhaul/icon.png",
-  "environment": "*",
-  
-  "custom": {
-    "modmenu:clientsideOnly": true
-  },
+  "environment": "client",
 
   "authors": [
     "Mirsario"


### PR DESCRIPTION
This change specifies the mod as client-side only not only for ModMenu, but also for Fabric.

Since ModMenu can detect that property, the ModMenu entry is also removed.