### PR TITLE
Add config menu using cloth-config

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,18 +21,18 @@ dependencies {
 
 	// Cloth Config
 	modApi("me.shedaniel.cloth:config-2:${project.cloth_config_version}") {
-        exclude(group: "net.fabricmc.fabric-api")
-        exclude(group: "net.fabricmc") // Prevent preparing two loader versions in cache. Not needed
-    }
+		exclude(group: "net.fabricmc.fabric-api")
+		exclude(group: "net.fabricmc") // Prevent preparing two loader versions in cache. Not needed
+	}
 	include "me.shedaniel.cloth:config-2:${project.cloth_config_version}"
 	
 	// Fabric Resource Loader (needed for localization, which Cloth Config needs)
 	// Actually not needed, because this is only used with ModMenu, and ModMenu includes it
-    //modApi(fabricApi.module("fabric-resource-loader-v0", project.fabric_version))
-    //include fabricApi.module("fabric-resource-loader-v0", project.fabric_version)
-    
-    // ModMenu API, to add the Config Screen to it
-    modImplementation "io.github.prospector:modmenu:${project.modmenu_version}"
+	//modApi(fabricApi.module("fabric-resource-loader-v0", project.fabric_version))
+	//include fabricApi.module("fabric-resource-loader-v0", project.fabric_version)
+	
+	// ModMenu API, to add the Config Screen to it
+	modImplementation "io.github.prospector:modmenu:${project.modmenu_version}"
 }
 
 processResources {

--- a/build.gradle
+++ b/build.gradle
@@ -19,14 +19,20 @@ dependencies {
 	// Fabric API. This is technically optional, but you probably want it anyway.
 	//modImplementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"
 
-	// PSA: Some older mods, compiled on Loom 0.2.1, might have outdated Maven POMs.
-	// You may need to force-disable transitiveness on them.
-
-	//ModMenu - Gave up on this because it's annoying. Feel free to do a PR!
-	//modImplementation("io.github.prospector:modmenu:${project.modmenu_version}") {
-	//	exclude(group: "net.fabricmc.fabric-api")
-	//	exclude(group: "net.fabricmc.fabric-loader")
-	//}
+	// Cloth Config
+	modApi("me.shedaniel.cloth:config-2:${project.cloth_config_version}") {
+        exclude(group: "net.fabricmc.fabric-api")
+        exclude(group: "net.fabricmc") // Prevent preparing two loader versions in cache. Not needed
+    }
+	include "me.shedaniel.cloth:config-2:${project.cloth_config_version}"
+	
+	// Fabric Resource Loader (needed for localization, which Cloth Config needs)
+	// Actually not needed, because this is only used with ModMenu, and ModMenu includes it
+    //modApi(fabricApi.module("fabric-resource-loader-v0", project.fabric_version))
+    //include fabricApi.module("fabric-resource-loader-v0", project.fabric_version)
+    
+    // ModMenu API, to add the Config Screen to it
+    modImplementation "io.github.prospector:modmenu:${project.modmenu_version}"
 }
 
 processResources {

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,9 +3,10 @@ org.gradle.jvmargs=-Xmx1G
 
 # Fabric Properties
 	# check these on https://fabricmc.net/use
-	minecraft_version=1.16.3
-	yarn_mappings=1.16.3+build.9
-	loader_version=0.4.8+build.157
+	# actually on https://modmuss50.me/fabric.html
+	minecraft_version=1.16.4
+	yarn_mappings=1.16.4+build.7
+	loader_version=0.10.8
 
 # Mod Properties
 	mod_version = 1.0.1-fabric-1.16
@@ -14,5 +15,6 @@ org.gradle.jvmargs=-Xmx1G
 
 # Dependencies
 	# currently not on the main fabric site, check on the maven: https://maven.fabricmc.net/net/fabricmc/fabric-api/fabric-api
-	fabric_version=0.3.0+build.200
-	# modmenu_version=1.14.6+build.31
+	fabric_version=0.28.3+1.16
+	cloth_config_version=4.8.3
+	modmenu_version=1.14.13+build.19

--- a/src/main/java/mirsario/cameraoverhaul/common/CameraOverhaul.java
+++ b/src/main/java/mirsario/cameraoverhaul/common/CameraOverhaul.java
@@ -12,12 +12,14 @@ public class CameraOverhaul
 
 	public static CameraOverhaul instance;
 	
+	public static String configFileName = "cameraoverhaul";
+	
 	public CameraSystem cameraSystem;
 	public ConfigData config;
 
 	public void onInitializeClient()
 	{
-		config = Configuration.LoadConfig(ConfigData.class, "cameraoverhaul", ConfigData.ConfigVersion);
+		config = Configuration.LoadConfig(ConfigData.class, configFileName, ConfigData.ConfigVersion);
 
 		cameraSystem = new CameraSystem();
 	}

--- a/src/main/java/mirsario/cameraoverhaul/core/configuration/Configuration.java
+++ b/src/main/java/mirsario/cameraoverhaul/core/configuration/Configuration.java
@@ -1,16 +1,10 @@
 package mirsario.cameraoverhaul.core.configuration;
 
-import mirsario.cameraoverhaul.common.CameraOverhaul;
-import net.fabricmc.loader.api.FabricLoader;
-
-import java.io.BufferedReader;
-import java.io.BufferedWriter;
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
+import mirsario.cameraoverhaul.common.*;
+import net.fabricmc.loader.api.*;
+import java.io.*;
+import java.nio.file.*;
+import com.google.gson.*;
 
 public final class Configuration
 {
@@ -21,7 +15,7 @@ public final class Configuration
 	public static <T extends BaseConfigData> T LoadConfig(Class<T> tClass, String configName, int configVersion)
 	{
 		T configData = null;
-		Path configFile = configPath.resolve(configName+".json");
+		Path configFile = configPath.resolve(configName + ".json");
 		boolean saveConfig = false;
 		
 		try {

--- a/src/main/java/mirsario/cameraoverhaul/core/configuration/Configuration.java
+++ b/src/main/java/mirsario/cameraoverhaul/core/configuration/Configuration.java
@@ -1,57 +1,65 @@
 package mirsario.cameraoverhaul.core.configuration;
 
-import com.google.gson.*;
-import java.io.*;
-import java.nio.file.*;
+import mirsario.cameraoverhaul.common.CameraOverhaul;
+import net.fabricmc.loader.api.FabricLoader;
+
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
 
 public final class Configuration
 {
 	private static Gson gson = new GsonBuilder().setPrettyPrinting().create();
+	
+	private static final Path configPath = FabricLoader.getInstance().getConfigDir();
 
 	public static <T extends BaseConfigData> T LoadConfig(Class<T> tClass, String configName, int configVersion)
 	{
 		T configData = null;
+		Path configFile = configPath.resolve(configName+".json");
+		boolean saveConfig = false;
 		
 		try {
-			Path configDir;
-			
-			configDir = Paths.get("", "config", configName + ".json");
-			
-			boolean saveConfig = false;
+			Files.createDirectories(configPath);
 
-			if(Files.exists(configDir)) {
-				FileReader fileReader = new FileReader(configDir.toFile());
+			if(Files.exists(configFile)) {
+				BufferedReader fileReader = Files.newBufferedReader(configFile);
 				configData = gson.fromJson(fileReader, tClass);
+				fileReader.close();
 				
 				//Save the config on first runs of new versions.
 				if(configData.configVersion < configVersion) {
 					saveConfig = true;
 				}
 			} else {
-				try {
-					configData = (T)tClass.newInstance();
-				}
-				catch(Exception e) {
-					e.printStackTrace();
-				}
-
+				configData = (T)tClass.getDeclaredConstructor().newInstance();
 				saveConfig = true;
 			}
-
-			if(saveConfig) {
-				Paths.get("", "config").toFile().mkdirs();
-				
-				configData.configVersion = configVersion;
-				
-				BufferedWriter writer = new BufferedWriter(new FileWriter(configDir.toFile()));
-				
-				writer.write(gson.toJson(configData));
-				writer.close();
-			}
 		} catch(Exception e) {
-			e.printStackTrace();
+			CameraOverhaul.Logger.error("Error when initializing config", e);
+		}
+		
+		if(saveConfig) {
+			SaveConfig(configData, configName, configVersion);
 		}
 		
 		return configData;
+	}
+	
+	public static <T extends BaseConfigData> void SaveConfig(T configData, String configName, int configVersion) {
+		Path configFile = configPath.resolve(configName+".json");
+		
+		configData.configVersion = configVersion;
+		
+		try (BufferedWriter writer = Files.newBufferedWriter(configFile)){
+			writer.write(gson.toJson(configData));
+		} catch (IOException e) {
+			CameraOverhaul.Logger.error("Couldn't save config file", e);
+		}
 	}
 }

--- a/src/main/java/mirsario/cameraoverhaul/fabric/ModMenuConfigIntegration.java
+++ b/src/main/java/mirsario/cameraoverhaul/fabric/ModMenuConfigIntegration.java
@@ -1,0 +1,77 @@
+package mirsario.cameraoverhaul.fabric;
+
+import io.github.prospector.modmenu.api.ConfigScreenFactory;
+import io.github.prospector.modmenu.api.ModMenuApi;
+import me.shedaniel.clothconfig2.api.ConfigBuilder;
+import me.shedaniel.clothconfig2.api.ConfigCategory;
+import me.shedaniel.clothconfig2.api.ConfigEntryBuilder;
+import mirsario.cameraoverhaul.common.CameraOverhaul;
+import mirsario.cameraoverhaul.common.configuration.ConfigData;
+import mirsario.cameraoverhaul.core.configuration.Configuration;
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.text.TranslatableText;
+
+public class ModMenuConfigIntegration implements ModMenuApi {
+	@Override
+	public ConfigScreenFactory<?> getModConfigScreenFactory() {
+		return screen -> getConfigBuilder().build();
+	}
+	
+	@SuppressWarnings("resource") //MinecraftClient.getInstance() isn't a resource
+	public static ConfigBuilder getConfigBuilder() {
+		ConfigData config = CameraOverhaul.instance.config;
+		
+		ConfigBuilder builder = ConfigBuilder.create()
+				.setParentScreen(MinecraftClient.getInstance().currentScreen)
+				.setTitle(new TranslatableText("cameraoverhaul.config.title"))
+				.transparentBackground()
+				.setSavingRunnable(()-> {
+					Configuration.SaveConfig(CameraOverhaul.instance.config, CameraOverhaul.configFileName, ConfigData.ConfigVersion);
+				});
+		
+		ConfigCategory general = builder.getOrCreateCategory(new TranslatableText("cameraoverhaul.config.category.general"));
+		ConfigEntryBuilder entryBuilder = builder.entryBuilder();
+		
+		// Enabled
+		general.addEntry(entryBuilder
+				.startBooleanToggle(new TranslatableText("cameraoverhaul.config.enabled.name"), config.enabled)
+					.setDefaultValue(true)
+					.setTooltip(new TranslatableText("cameraoverhaul.config.enabled.tooltip"))
+					.setSaveConsumer(newValue -> config.enabled = newValue)
+					.build());
+		
+		// strafingRollFactor
+		general.addEntry(entryBuilder
+					.startFloatField(new TranslatableText("cameraoverhaul.config.strafingrollfactor.name"), config.strafingRollFactor)
+					.setDefaultValue(1.0F)
+					.setTooltip(new TranslatableText("cameraoverhaul.config.strafingrollfactor.tooltip"))
+					.setSaveConsumer(newValue -> config.strafingRollFactor = newValue)
+					.build());
+		
+		// yawDeltaRollFactor
+		general.addEntry(entryBuilder
+				.startFloatField(new TranslatableText("cameraoverhaul.config.yawdeltarollfactor.name"), config.yawDeltaRollFactor)
+					.setDefaultValue(1.0F)
+					.setTooltip(new TranslatableText("cameraoverhaul.config.yawdeltarollfactor.tooltip"))
+					.setSaveConsumer(newValue -> config.yawDeltaRollFactor = newValue)
+					.build());
+		
+		// verticalVelocityPitchFactor
+		general.addEntry(entryBuilder
+				.startFloatField(new TranslatableText("cameraoverhaul.config.verticalvelocitypitchfactor.name"), config.verticalVelocityPitchFactor)
+					.setDefaultValue(1.0F)
+					.setTooltip(new TranslatableText("cameraoverhaul.config.verticalvelocitypitchfactor.tooltip"))
+					.setSaveConsumer(newValue -> config.verticalVelocityPitchFactor = newValue)
+					.build());
+		
+		// forwardVelocityPitchFactor
+		general.addEntry(entryBuilder
+				.startFloatField(new TranslatableText("cameraoverhaul.config.forwardvelocitypitchfactor.name"), config.forwardVelocityPitchFactor)
+					.setDefaultValue(1.0F)
+					.setTooltip(new TranslatableText("cameraoverhaul.config.forwardvelocitypitchfactor.tooltip"))
+					.setSaveConsumer(newValue -> config.forwardVelocityPitchFactor = newValue)
+					.build());
+		
+		return builder;
+	}
+}

--- a/src/main/java/mirsario/cameraoverhaul/fabric/ModMenuConfigIntegration.java
+++ b/src/main/java/mirsario/cameraoverhaul/fabric/ModMenuConfigIntegration.java
@@ -11,66 +11,74 @@ import mirsario.cameraoverhaul.core.configuration.Configuration;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.text.TranslatableText;
 
-public class ModMenuConfigIntegration implements ModMenuApi {
+public class ModMenuConfigIntegration implements ModMenuApi
+{
 	@Override
-	public ConfigScreenFactory<?> getModConfigScreenFactory() {
-		return screen -> getConfigBuilder().build();
+	public ConfigScreenFactory<?> getModConfigScreenFactory()
+	{
+		return screen -> GetConfigBuilder().build();
 	}
 	
 	@SuppressWarnings("resource") //MinecraftClient.getInstance() isn't a resource
-	public static ConfigBuilder getConfigBuilder() {
+	public static ConfigBuilder GetConfigBuilder()
+	{
 		ConfigData config = CameraOverhaul.instance.config;
 		
 		ConfigBuilder builder = ConfigBuilder.create()
-				.setParentScreen(MinecraftClient.getInstance().currentScreen)
-				.setTitle(new TranslatableText("cameraoverhaul.config.title"))
-				.transparentBackground()
-				.setSavingRunnable(()-> {
-					Configuration.SaveConfig(CameraOverhaul.instance.config, CameraOverhaul.configFileName, ConfigData.ConfigVersion);
-				});
+			.setParentScreen(MinecraftClient.getInstance().currentScreen)
+			.setTitle(new TranslatableText("cameraoverhaul.config.title"))
+			.transparentBackground()
+			.setSavingRunnable(() -> {
+				Configuration.SaveConfig(CameraOverhaul.instance.config, CameraOverhaul.configFileName, ConfigData.ConfigVersion);
+			});
 		
 		ConfigCategory general = builder.getOrCreateCategory(new TranslatableText("cameraoverhaul.config.category.general"));
 		ConfigEntryBuilder entryBuilder = builder.entryBuilder();
 		
 		// Enabled
 		general.addEntry(entryBuilder
-				.startBooleanToggle(new TranslatableText("cameraoverhaul.config.enabled.name"), config.enabled)
-					.setDefaultValue(true)
-					.setTooltip(new TranslatableText("cameraoverhaul.config.enabled.tooltip"))
-					.setSaveConsumer(newValue -> config.enabled = newValue)
-					.build());
+			.startBooleanToggle(new TranslatableText("cameraoverhaul.config.enabled.name"), config.enabled)
+			.setDefaultValue(true)
+			.setTooltip(new TranslatableText("cameraoverhaul.config.enabled.tooltip"))
+			.setSaveConsumer(newValue -> config.enabled = newValue)
+			.build()
+		);
 		
 		// strafingRollFactor
 		general.addEntry(entryBuilder
-					.startIntSlider(new TranslatableText("cameraoverhaul.config.strafingrollfactor.name"), (int) (config.strafingRollFactor*100), 0, 1000)
-					.setDefaultValue(100)
-					.setTooltip(new TranslatableText("cameraoverhaul.config.strafingrollfactor.tooltip"))
-					.setSaveConsumer(newValue -> config.strafingRollFactor = newValue/100F)
-					.build());
+			.startIntSlider(new TranslatableText("cameraoverhaul.config.strafingrollfactor.name"), (int) (config.strafingRollFactor*100), 0, 1000)
+			.setDefaultValue(100)
+			.setTooltip(new TranslatableText("cameraoverhaul.config.strafingrollfactor.tooltip"))
+			.setSaveConsumer(newValue -> config.strafingRollFactor = newValue / 100f)
+			.build()
+		);
 		
 		// yawDeltaRollFactor
 		general.addEntry(entryBuilder
-				.startIntSlider(new TranslatableText("cameraoverhaul.config.yawdeltarollfactor.name"), (int) (config.yawDeltaRollFactor*100F), 0, 1000)
-					.setDefaultValue(100)
-					.setTooltip(new TranslatableText("cameraoverhaul.config.yawdeltarollfactor.tooltip"))
-					.setSaveConsumer(newValue -> config.yawDeltaRollFactor = newValue/100F)
-					.build());
+			.startIntSlider(new TranslatableText("cameraoverhaul.config.yawdeltarollfactor.name"), (int) (config.yawDeltaRollFactor*100F), 0, 1000)
+			.setDefaultValue(100)
+			.setTooltip(new TranslatableText("cameraoverhaul.config.yawdeltarollfactor.tooltip"))
+			.setSaveConsumer(newValue -> config.yawDeltaRollFactor = newValue / 100f)
+			.build()
+		);
 		
 		// verticalVelocityPitchFactor
 		general.addEntry(entryBuilder
-				.startIntSlider(new TranslatableText("cameraoverhaul.config.verticalvelocitypitchfactor.name"), (int) (config.verticalVelocityPitchFactor*100), 0, 1000)
-					.setDefaultValue(100)
-					.setTooltip(new TranslatableText("cameraoverhaul.config.verticalvelocitypitchfactor.tooltip"))
-					.setSaveConsumer(newValue -> config.verticalVelocityPitchFactor = newValue/100F)
-					.build());
+			.startIntSlider(new TranslatableText("cameraoverhaul.config.verticalvelocitypitchfactor.name"), (int) (config.verticalVelocityPitchFactor*100), 0, 1000)
+			.setDefaultValue(100)
+			.setTooltip(new TranslatableText("cameraoverhaul.config.verticalvelocitypitchfactor.tooltip"))
+			.setSaveConsumer(newValue -> config.verticalVelocityPitchFactor = newValue / 100f)
+			.build()
+		);
 		
 		// forwardVelocityPitchFactor
 		general.addEntry(entryBuilder
-				.startIntSlider(new TranslatableText("cameraoverhaul.config.forwardvelocitypitchfactor.name"), (int) (config.forwardVelocityPitchFactor*100), 0, 1000)
-					.setDefaultValue(100)
-					.setTooltip(new TranslatableText("cameraoverhaul.config.forwardvelocitypitchfactor.tooltip"))
-					.setSaveConsumer(newValue -> config.forwardVelocityPitchFactor = newValue/100F)
-					.build());
+			.startIntSlider(new TranslatableText("cameraoverhaul.config.forwardvelocitypitchfactor.name"), (int) (config.forwardVelocityPitchFactor*100), 0, 1000)
+			.setDefaultValue(100)
+			.setTooltip(new TranslatableText("cameraoverhaul.config.forwardvelocitypitchfactor.tooltip"))
+			.setSaveConsumer(newValue -> config.forwardVelocityPitchFactor = newValue / 100f)
+			.build()
+		);
 		
 		return builder;
 	}

--- a/src/main/java/mirsario/cameraoverhaul/fabric/ModMenuConfigIntegration.java
+++ b/src/main/java/mirsario/cameraoverhaul/fabric/ModMenuConfigIntegration.java
@@ -1,18 +1,19 @@
 package mirsario.cameraoverhaul.fabric;
 
-import io.github.prospector.modmenu.api.ConfigScreenFactory;
-import io.github.prospector.modmenu.api.ModMenuApi;
-import me.shedaniel.clothconfig2.api.ConfigBuilder;
-import me.shedaniel.clothconfig2.api.ConfigCategory;
-import me.shedaniel.clothconfig2.api.ConfigEntryBuilder;
-import mirsario.cameraoverhaul.common.CameraOverhaul;
-import mirsario.cameraoverhaul.common.configuration.ConfigData;
-import mirsario.cameraoverhaul.core.configuration.Configuration;
-import net.minecraft.client.MinecraftClient;
-import net.minecraft.text.TranslatableText;
+import java.util.function.*;
+import io.github.prospector.modmenu.api.*;
+import me.shedaniel.clothconfig2.api.*;
+import me.shedaniel.clothconfig2.gui.entries.*;
+import mirsario.cameraoverhaul.common.*;
+import mirsario.cameraoverhaul.common.configuration.*;
+import mirsario.cameraoverhaul.core.configuration.*;
+import net.minecraft.client.*;
+import net.minecraft.text.*;
 
 public class ModMenuConfigIntegration implements ModMenuApi
 {
+	private static final String ConfigEntriesPrefix = "cameraoverhaul.config";
+
 	@Override
 	public ConfigScreenFactory<?> getModConfigScreenFactory()
 	{
@@ -35,51 +36,36 @@ public class ModMenuConfigIntegration implements ModMenuApi
 		ConfigCategory general = builder.getOrCreateCategory(new TranslatableText("cameraoverhaul.config.category.general"));
 		ConfigEntryBuilder entryBuilder = builder.entryBuilder();
 		
-		// Enabled
-		general.addEntry(entryBuilder
-			.startBooleanToggle(new TranslatableText("cameraoverhaul.config.enabled.name"), config.enabled)
-			.setDefaultValue(true)
-			.setTooltip(new TranslatableText("cameraoverhaul.config.enabled.tooltip"))
-			.setSaveConsumer(newValue -> config.enabled = newValue)
-			.build()
-		);
-		
-		// strafingRollFactor
-		general.addEntry(entryBuilder
-			.startIntSlider(new TranslatableText("cameraoverhaul.config.strafingrollfactor.name"), (int) (config.strafingRollFactor*100), 0, 1000)
-			.setDefaultValue(100)
-			.setTooltip(new TranslatableText("cameraoverhaul.config.strafingrollfactor.tooltip"))
-			.setSaveConsumer(newValue -> config.strafingRollFactor = newValue / 100f)
-			.build()
-		);
-		
-		// yawDeltaRollFactor
-		general.addEntry(entryBuilder
-			.startIntSlider(new TranslatableText("cameraoverhaul.config.yawdeltarollfactor.name"), (int) (config.yawDeltaRollFactor*100F), 0, 1000)
-			.setDefaultValue(100)
-			.setTooltip(new TranslatableText("cameraoverhaul.config.yawdeltarollfactor.tooltip"))
-			.setSaveConsumer(newValue -> config.yawDeltaRollFactor = newValue / 100f)
-			.build()
-		);
-		
-		// verticalVelocityPitchFactor
-		general.addEntry(entryBuilder
-			.startIntSlider(new TranslatableText("cameraoverhaul.config.verticalvelocitypitchfactor.name"), (int) (config.verticalVelocityPitchFactor*100), 0, 1000)
-			.setDefaultValue(100)
-			.setTooltip(new TranslatableText("cameraoverhaul.config.verticalvelocitypitchfactor.tooltip"))
-			.setSaveConsumer(newValue -> config.verticalVelocityPitchFactor = newValue / 100f)
-			.build()
-		);
-		
-		// forwardVelocityPitchFactor
-		general.addEntry(entryBuilder
-			.startIntSlider(new TranslatableText("cameraoverhaul.config.forwardvelocitypitchfactor.name"), (int) (config.forwardVelocityPitchFactor*100), 0, 1000)
-			.setDefaultValue(100)
-			.setTooltip(new TranslatableText("cameraoverhaul.config.forwardvelocitypitchfactor.tooltip"))
-			.setSaveConsumer(newValue -> config.forwardVelocityPitchFactor = newValue / 100f)
-			.build()
-		);
+		//Entries
+		general.addEntry(CreateBooleanEntry(entryBuilder, "enabled", true, config.enabled, value -> config.enabled = value));
+		general.addEntry(CreateFloatFactorEntry(entryBuilder, "strafingRollFactor", 1.0f, config.strafingRollFactor, value -> config.strafingRollFactor = value));
+		general.addEntry(CreateFloatFactorEntry(entryBuilder, "yawDeltaRollFactor", 1.0f, config.yawDeltaRollFactor, value -> config.yawDeltaRollFactor = value));
+		general.addEntry(CreateFloatFactorEntry(entryBuilder, "verticalVelocityPitchFactor", 1.0f, config.verticalVelocityPitchFactor, value -> config.verticalVelocityPitchFactor = value));
+		general.addEntry(CreateFloatFactorEntry(entryBuilder, "forwardVelocityPitchFactor", 1.0f, config.forwardVelocityPitchFactor, value -> config.forwardVelocityPitchFactor = value));
 		
 		return builder;
+	}
+	//Entry Helpers
+	public static BooleanListEntry CreateBooleanEntry(ConfigEntryBuilder entryBuilder, String entryName, Boolean defaultValue, Boolean value, Function<Boolean, Boolean> setter)
+	{
+		String lowerCaseName = entryName.toLowerCase();
+		String baseTranslationPath = ConfigEntriesPrefix + "." + lowerCaseName;
+
+		return entryBuilder.startBooleanToggle(new TranslatableText(baseTranslationPath + ".name"), value)
+			.setDefaultValue(defaultValue)
+			.setTooltip(new TranslatableText(baseTranslationPath + ".tooltip"))
+			.setSaveConsumer(newValue -> setter.apply(newValue))
+			.build();
+	}
+	public static FloatListEntry CreateFloatFactorEntry(ConfigEntryBuilder entryBuilder, String entryName, float defaultValue, float value, Function<Float, Float> setter)
+	{
+		String lowerCaseName = entryName.toLowerCase();
+		String baseTranslationPath = ConfigEntriesPrefix + "." + lowerCaseName;
+
+		return entryBuilder.startFloatField(new TranslatableText(baseTranslationPath + ".name"), value)
+			.setDefaultValue(defaultValue)
+			.setTooltip(new TranslatableText(baseTranslationPath + ".tooltip"))
+			.setSaveConsumer(newValue -> setter.apply(newValue))
+			.build();
 	}
 }

--- a/src/main/java/mirsario/cameraoverhaul/fabric/ModMenuConfigIntegration.java
+++ b/src/main/java/mirsario/cameraoverhaul/fabric/ModMenuConfigIntegration.java
@@ -42,34 +42,34 @@ public class ModMenuConfigIntegration implements ModMenuApi {
 		
 		// strafingRollFactor
 		general.addEntry(entryBuilder
-					.startFloatField(new TranslatableText("cameraoverhaul.config.strafingrollfactor.name"), config.strafingRollFactor)
-					.setDefaultValue(1.0F)
+					.startIntSlider(new TranslatableText("cameraoverhaul.config.strafingrollfactor.name"), (int) (config.strafingRollFactor*100), 0, 1000)
+					.setDefaultValue(100)
 					.setTooltip(new TranslatableText("cameraoverhaul.config.strafingrollfactor.tooltip"))
-					.setSaveConsumer(newValue -> config.strafingRollFactor = newValue)
+					.setSaveConsumer(newValue -> config.strafingRollFactor = newValue/100F)
 					.build());
 		
 		// yawDeltaRollFactor
 		general.addEntry(entryBuilder
-				.startFloatField(new TranslatableText("cameraoverhaul.config.yawdeltarollfactor.name"), config.yawDeltaRollFactor)
-					.setDefaultValue(1.0F)
+				.startIntSlider(new TranslatableText("cameraoverhaul.config.yawdeltarollfactor.name"), (int) (config.yawDeltaRollFactor*100F), 0, 1000)
+					.setDefaultValue(100)
 					.setTooltip(new TranslatableText("cameraoverhaul.config.yawdeltarollfactor.tooltip"))
-					.setSaveConsumer(newValue -> config.yawDeltaRollFactor = newValue)
+					.setSaveConsumer(newValue -> config.yawDeltaRollFactor = newValue/100F)
 					.build());
 		
 		// verticalVelocityPitchFactor
 		general.addEntry(entryBuilder
-				.startFloatField(new TranslatableText("cameraoverhaul.config.verticalvelocitypitchfactor.name"), config.verticalVelocityPitchFactor)
-					.setDefaultValue(1.0F)
+				.startIntSlider(new TranslatableText("cameraoverhaul.config.verticalvelocitypitchfactor.name"), (int) (config.verticalVelocityPitchFactor*100), 0, 1000)
+					.setDefaultValue(100)
 					.setTooltip(new TranslatableText("cameraoverhaul.config.verticalvelocitypitchfactor.tooltip"))
-					.setSaveConsumer(newValue -> config.verticalVelocityPitchFactor = newValue)
+					.setSaveConsumer(newValue -> config.verticalVelocityPitchFactor = newValue/100F)
 					.build());
 		
 		// forwardVelocityPitchFactor
 		general.addEntry(entryBuilder
-				.startFloatField(new TranslatableText("cameraoverhaul.config.forwardvelocitypitchfactor.name"), config.forwardVelocityPitchFactor)
-					.setDefaultValue(1.0F)
+				.startIntSlider(new TranslatableText("cameraoverhaul.config.forwardvelocitypitchfactor.name"), (int) (config.forwardVelocityPitchFactor*100), 0, 1000)
+					.setDefaultValue(100)
 					.setTooltip(new TranslatableText("cameraoverhaul.config.forwardvelocitypitchfactor.tooltip"))
-					.setSaveConsumer(newValue -> config.forwardVelocityPitchFactor = newValue)
+					.setSaveConsumer(newValue -> config.forwardVelocityPitchFactor = newValue/100F)
 					.build());
 		
 		return builder;

--- a/src/main/resources/assets/cameraoverhaul/lang/en_us.json
+++ b/src/main/resources/assets/cameraoverhaul/lang/en_us.json
@@ -1,0 +1,14 @@
+{
+	"cameraoverhaul.config.title": "CameraOverhaul Settings",
+	"cameraoverhaul.config.category.general": "General",
+	"cameraoverhaul.config.enabled.name": "Enable the mod's effects",
+	"cameraoverhaul.config.enabled.tooltip": "",
+	"cameraoverhaul.config.strafingrollfactor.name": "strafingrollfactor",
+	"cameraoverhaul.config.strafingrollfactor.tooltip": "",
+	"cameraoverhaul.config.yawdeltarollfactor.name": "yawdeltarollfactor",
+	"cameraoverhaul.config.yawdeltarollfactor.tooltip": "",
+	"cameraoverhaul.config.verticalvelocitypitchfactor.name": "verticalvelocitypitchfactor",
+	"cameraoverhaul.config.verticalvelocitypitchfactor.tooltip": "",
+	"cameraoverhaul.config.forwardvelocitypitchfactor.name": "forwardvelocitypitchfactor",
+	"cameraoverhaul.config.forwardvelocitypitchfactor.tooltip": ""
+}

--- a/src/main/resources/assets/cameraoverhaul/lang/en_us.json
+++ b/src/main/resources/assets/cameraoverhaul/lang/en_us.json
@@ -3,12 +3,12 @@
 	"cameraoverhaul.config.category.general": "General",
 	"cameraoverhaul.config.enabled.name": "Enable the mod's effects",
 	"cameraoverhaul.config.enabled.tooltip": "",
-	"cameraoverhaul.config.strafingrollfactor.name": "strafingrollfactor",
-	"cameraoverhaul.config.strafingrollfactor.tooltip": "",
-	"cameraoverhaul.config.yawdeltarollfactor.name": "yawdeltarollfactor",
-	"cameraoverhaul.config.yawdeltarollfactor.tooltip": "",
-	"cameraoverhaul.config.verticalvelocitypitchfactor.name": "verticalvelocitypitchfactor",
-	"cameraoverhaul.config.verticalvelocitypitchfactor.tooltip": "",
-	"cameraoverhaul.config.forwardvelocitypitchfactor.name": "forwardvelocitypitchfactor",
-	"cameraoverhaul.config.forwardvelocitypitchfactor.tooltip": ""
+	"cameraoverhaul.config.strafingrollfactor.name": "Strafing Roll Factor",
+	"cameraoverhaul.config.strafingrollfactor.tooltip": "Controls the strength of the camera roll rotation caused by strafing, or sideway horizontal velocity.",
+	"cameraoverhaul.config.yawdeltarollfactor.name": "Mouselook Roll Factor",
+	"cameraoverhaul.config.yawdeltarollfactor.tooltip": "Controls the strength of the camera roll rotation caused by turning around horizontally.",
+	"cameraoverhaul.config.verticalvelocitypitchfactor.name": "Vertical Velocity Pitch Factor",
+	"cameraoverhaul.config.verticalvelocitypitchfactor.tooltip": "Controls the strength of the camera pitch rotation offset caused by vertical velocity.",
+	"cameraoverhaul.config.forwardvelocitypitchfactor.name": "Forward Velocity Pitch Factor",
+	"cameraoverhaul.config.forwardvelocitypitchfactor.tooltip": "Controls the strength of the camera pitch rotation offset caused by moving forward or backwards."
 }

--- a/src/main/resources/assets/cameraoverhaul/lang/en_us.json
+++ b/src/main/resources/assets/cameraoverhaul/lang/en_us.json
@@ -2,7 +2,7 @@
 	"cameraoverhaul.config.title": "CameraOverhaul Settings",
 	"cameraoverhaul.config.category.general": "General",
 	"cameraoverhaul.config.enabled.name": "Enable the mod's effects",
-	"cameraoverhaul.config.enabled.tooltip": "",
+	"cameraoverhaul.config.enabled.tooltip": "Toggles all of the mod's features.",
 	"cameraoverhaul.config.strafingrollfactor.name": "Strafing Roll Factor",
 	"cameraoverhaul.config.strafingrollfactor.tooltip": "Controls the strength of the camera roll rotation caused by strafing, or sideway horizontal velocity.",
 	"cameraoverhaul.config.yawdeltarollfactor.name": "Mouselook Roll Factor",

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -20,7 +20,8 @@
   },
 
   "entrypoints": {
-	"client": [ "mirsario.cameraoverhaul.fabric.FabricClientModInitializer" ]
+	"client": [ "mirsario.cameraoverhaul.fabric.FabricClientModInitializer" ],
+	"modmenu": [ "mirsario.cameraoverhaul.fabric.ModMenuConfigIntegration" ]
   },
   
   "mixins": [
@@ -28,6 +29,8 @@
   ],
 
   "depends": {
-    "fabricloader": ">=0.4.0"
+    "fabricloader": ">=0.4.0",
+    "fabric-resource-loader-v0": ">=0.3.1",
+    "cloth-config2": ">=4.8.3"
   }
 }

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -3,13 +3,17 @@
   "id": "cameraoverhaul",
   "version": "${version}",
   "name": "Camera Overhaul",
-  "description": "Makes gameplay more satisfying through the use of various camera tilting. Compatible with everything.\nConfigurable through '.minecraft/config/cameraoverhaul.json'.",
+  "description": "Makes gameplay more satisfying through the use of various camera tilting. Compatible with everything.\nConfigurable through the gear button in the top right of ModMenu or through the '.minecraft/config/cameraoverhaul.json' file for finer control.",
   "license": "MIT",
   "icon": "assets/cameraoverhaul/icon.png",
   "environment": "client",
 
   "authors": [
     "Mirsario"
+  ],
+
+  "contributors": [
+    "altrisi"
   ],
 
   "contact": {

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -34,7 +34,6 @@
 
   "depends": {
     "fabricloader": ">=0.4.0",
-    "fabric-resource-loader-v0": ">=0.3.1",
     "cloth-config2": ">=4.8.3"
   }
 }


### PR DESCRIPTION
Resolves #4.

This PR adds a config menu using [cloth-config](https://shedaniel.gitbook.io/cloth-config/), as discussed in #4.

In order to make the values more user-friendly, it multiplies the value by 100 and then adds it as a slider (cloth-config sadly doesn't support float sliders). If the user updated the config file to add a more precise value, changing other values shouldn't make that field get less precision. In the menu, values are capped to 1000.

Preview:

![2020-12-23_21 18 47](https://user-images.githubusercontent.com/17107132/103034145-85df9280-4564-11eb-83db-bc7527586075.png)

As you can see in the image, this PR doesn't add proper names (neither tooltips) to the settings. That's because I don't exactly know what does each setting do, and hope you will be able to explain them better. I may PR a translation after you add them.

In the end, only cloth-config needed to be included, since it only requires Fabric Resource Loader when running (only to load translations, it doesn't actually call the API), and ModMenu includes it. Since the config menu can (currently) only be seen via ModMenu, Resource Loader is assured to be installed when the menu is shown and everyone will be happy. In case you want to add other ways to open the config menu besides ModMenu, then you would need to include it. I left the Gradle lines commented out in case you ever want to do that.

Although it's in the `fabric` package, the function `ModMenuConfigIntegration#getConfigBuilder()` can also be used in other loaders, since cloth-config shares the same API with the other loaders it supports.

I also restructured the `Configuration` class a bit. I started doing so because it was needed (required to split save), but I ended up changing a bit more than that.

Also updated mappings and loader versions in the process (you might need to refresh Gradle project if your IDE doesn't do it automatically).