### PR TITLE
Add only enable when flying option

### DIFF
--- a/src/main/java/mirsario/cameraoverhaul/common/configuration/ConfigData.java
+++ b/src/main/java/mirsario/cameraoverhaul/common/configuration/ConfigData.java
@@ -7,6 +7,7 @@ public class ConfigData extends BaseConfigData
 	public static final int ConfigVersion = 1;
 
 	public boolean enabled = true;
+	public boolean onlyEnableWhenFlying = false;
 	public float strafingRollFactor = 1.0f;
 	public float yawDeltaRollFactor = 1.0f;
 	public float verticalVelocityPitchFactor = 1.0f;

--- a/src/main/java/mirsario/cameraoverhaul/common/systems/CameraSystem.java
+++ b/src/main/java/mirsario/cameraoverhaul/common/systems/CameraSystem.java
@@ -19,6 +19,7 @@ public final class CameraSystem implements CameraUpdateCallback, ModifyCameraTra
 	private static double yawDeltaRollTargetOffset;
 	private static double lerpSpeed = 1d;
 	private static Transform offsetTransform = new Transform();
+	public static boolean isFlying = false;
 
 	public CameraSystem()
 	{
@@ -44,12 +45,27 @@ public final class CameraSystem implements CameraUpdateCallback, ModifyCameraTra
 		Vec3d velocity = camera.getFocusedEntity().getVelocity();
 		Vec2f relativeXZVelocity = Vec2fUtils.Rotate(new Vec2f((float)velocity.x, (float)velocity.z), 360f - (float)cameraTransform.eulerRot.y);
 
-		//X
-		VerticalVelocityPitchOffset(cameraTransform, offsetTransform, velocity, relativeXZVelocity, deltaTime, config.verticalVelocityPitchFactor);
-		ForwardVelocityPitchOffset(cameraTransform, offsetTransform, velocity, relativeXZVelocity, deltaTime, config.forwardVelocityPitchFactor);
-		//Z
-		YawDeltaRollOffset(cameraTransform, offsetTransform, velocity, relativeXZVelocity, deltaTime, config.yawDeltaRollFactor);
-		StrafingRollOffset(cameraTransform, offsetTransform, velocity, relativeXZVelocity, deltaTime, config.strafingRollFactor);
+		if (config.onlyEnableWhenFlying) {
+			if (isFlying) {
+				//X
+				VerticalVelocityPitchOffset(cameraTransform, offsetTransform, velocity, relativeXZVelocity, deltaTime, config.verticalVelocityPitchFactor);
+				ForwardVelocityPitchOffset(cameraTransform, offsetTransform, velocity, relativeXZVelocity, deltaTime, config.forwardVelocityPitchFactor);
+				//Z
+				YawDeltaRollOffset(cameraTransform, offsetTransform, velocity, relativeXZVelocity, deltaTime, config.yawDeltaRollFactor);
+				StrafingRollOffset(cameraTransform, offsetTransform, velocity, relativeXZVelocity, deltaTime, config.strafingRollFactor);
+			}
+			else {
+				yawDeltaRollTargetOffset = MathUtils.Lerp(yawDeltaRollTargetOffset, 0d, deltaTime * 0.35d);
+			}
+		}
+		else {
+			//X
+			VerticalVelocityPitchOffset(cameraTransform, offsetTransform, velocity, relativeXZVelocity, deltaTime, config.verticalVelocityPitchFactor);
+			ForwardVelocityPitchOffset(cameraTransform, offsetTransform, velocity, relativeXZVelocity, deltaTime, config.forwardVelocityPitchFactor);
+			//Z
+			YawDeltaRollOffset(cameraTransform, offsetTransform, velocity, relativeXZVelocity, deltaTime, config.yawDeltaRollFactor);
+			StrafingRollOffset(cameraTransform, offsetTransform, velocity, relativeXZVelocity, deltaTime, config.strafingRollFactor);
+		}
 
 		prevCameraYaw = cameraTransform.eulerRot.y;
 	}

--- a/src/main/java/mirsario/cameraoverhaul/fabric/ModMenuConfigIntegration.java
+++ b/src/main/java/mirsario/cameraoverhaul/fabric/ModMenuConfigIntegration.java
@@ -44,11 +44,12 @@ public class ModMenuConfigIntegration implements ModMenuApi
 		
 		//Entries
 		general.addEntry(CreateBooleanEntry(entryBuilder, "enabled", true, config.enabled, value -> config.enabled = value));
+		general.addEntry(CreateBooleanEntry(entryBuilder, "onlyEnableWhenFlying", true, config.onlyEnableWhenFlying, value -> config.onlyEnableWhenFlying = value));
 		general.addEntry(CreateFloatFactorEntry(entryBuilder, "strafingRollFactor", 1.0f, config.strafingRollFactor, value -> config.strafingRollFactor = value));
 		general.addEntry(CreateFloatFactorEntry(entryBuilder, "yawDeltaRollFactor", 1.0f, config.yawDeltaRollFactor, value -> config.yawDeltaRollFactor = value));
 		general.addEntry(CreateFloatFactorEntry(entryBuilder, "verticalVelocityPitchFactor", 1.0f, config.verticalVelocityPitchFactor, value -> config.verticalVelocityPitchFactor = value));
 		general.addEntry(CreateFloatFactorEntry(entryBuilder, "forwardVelocityPitchFactor", 1.0f, config.forwardVelocityPitchFactor, value -> config.forwardVelocityPitchFactor = value));
-		
+
 		return builder;
 	}
 	//Entry Helpers

--- a/src/main/java/mirsario/cameraoverhaul/fabric/mixins/modern/CameraMixin.java
+++ b/src/main/java/mirsario/cameraoverhaul/fabric/mixins/modern/CameraMixin.java
@@ -1,7 +1,10 @@
 package mirsario.cameraoverhaul.fabric.mixins.modern;
 
+import mirsario.cameraoverhaul.common.CameraOverhaul;
+import mirsario.cameraoverhaul.common.systems.CameraSystem;
 import net.minecraft.client.render.*;
 import net.minecraft.entity.*;
+import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.util.math.Vec3d;
 import net.minecraft.world.*;
 import org.spongepowered.asm.mixin.*;
@@ -23,6 +26,13 @@ public abstract class CameraMixin
 	private void OnCameraUpdate(BlockView area, Entity focusedEntity, boolean thirdPerson, boolean inverseView, float tickDelta, CallbackInfo ci)
 	{
 		Transform cameraTransform = new Transform(getPos(), new Vec3d(getPitch(), getYaw(), 0d));
+
+		if (CameraOverhaul.instance.config.onlyEnableWhenFlying) {
+			if (((PlayerEntity) focusedEntity).isFallFlying())
+				CameraSystem.isFlying = true;
+			else
+				CameraSystem.isFlying = false;
+		}
 
 		CameraUpdateCallback.EVENT.Invoker().OnCameraUpdate((Camera)(Object)this, cameraTransform, tickDelta);
 

--- a/src/main/resources/assets/cameraoverhaul/lang/en_us.json
+++ b/src/main/resources/assets/cameraoverhaul/lang/en_us.json
@@ -4,7 +4,7 @@
 	"cameraoverhaul.config.enabled.name": "Enable the mod's effects",
 	"cameraoverhaul.config.enabled.tooltip": "Toggles all of the mod's features.",
 	"cameraoverhaul.config.onlyenablewhenflying.name": "Only Enable if Flying",
-	"cameraoverhaul.config.onlyenablewhenflying.tooltip": "Enables mouselook roll if flying, disables everything if not flying.",
+	"cameraoverhaul.config.onlyenablewhenflying.tooltip": "Enables when flying, disables everything when not flying.",
 	"cameraoverhaul.config.strafingrollfactor.name": "Strafing Roll Factor",
 	"cameraoverhaul.config.strafingrollfactor.tooltip": "Controls the strength of the camera roll rotation caused by strafing, or sideway horizontal velocity.",
 	"cameraoverhaul.config.yawdeltarollfactor.name": "Mouselook Roll Factor",

--- a/src/main/resources/assets/cameraoverhaul/lang/en_us.json
+++ b/src/main/resources/assets/cameraoverhaul/lang/en_us.json
@@ -3,6 +3,8 @@
 	"cameraoverhaul.config.category.general": "General",
 	"cameraoverhaul.config.enabled.name": "Enable the mod's effects",
 	"cameraoverhaul.config.enabled.tooltip": "Toggles all of the mod's features.",
+	"cameraoverhaul.config.onlyenablewhenflying.name": "Only Enable if Flying",
+	"cameraoverhaul.config.onlyenablewhenflying.tooltip": "Enables mouselook roll if flying, disables everything if not flying.",
 	"cameraoverhaul.config.strafingrollfactor.name": "Strafing Roll Factor",
 	"cameraoverhaul.config.strafingrollfactor.tooltip": "Controls the strength of the camera roll rotation caused by strafing, or sideway horizontal velocity.",
 	"cameraoverhaul.config.yawdeltarollfactor.name": "Mouselook Roll Factor",


### PR DESCRIPTION
This adds an option to only tilt the camera if the player is flying. The code is pretty sloppy but somehow it works.