### PR TITLE
fix camera smoothing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,12 @@
 | [1.0.1](#101)                         | `2020-12-06` |
 | [1.0.0](#100)                         | `2020-11-30` |
 
+# Work In Progress
+- Fixed issue [#115](https://github.com/Mirsario/Minecraft-CameraOverhaul/issues/115) (Audio is reversed)
+  (Thanks, `@archiso86`!)
+- Fixed issue [#113](https://github.com/Mirsario/Minecraft-CameraOverhaul/issues/113) (Problems With On-Screen HUD Element Rendering)
+  (Thanks, `@archiso86`!)
+
 # 2.1.0
 
 - Minecraft 26.1+ support.

--- a/src/main/java/mirsario/cameraoverhaul/mixins/CameraMixin.java
+++ b/src/main/java/mirsario/cameraoverhaul/mixins/CameraMixin.java
@@ -29,9 +29,15 @@ import org.joml.*;
 @Mixin(Camera.class)
 @SuppressWarnings("UnusedMixin")
 public abstract class CameraMixin {
+	//? if >=1.21.11 {
 	private static final Vector3f FORWARDS = new Vector3f(0, 0, -1);
 	private static final Vector3f UP = new Vector3f(0, 1, 0);
 	private static final Vector3f LEFT = new Vector3f(-1, 0, 0);
+	//?} else {
+	/*private static final Vector3f FORWARDS = new Vector3f(0, 0, 1);
+	private static final Vector3f UP = new Vector3f(0, 1, 0);
+	private static final Vector3f LEFT = new Vector3f(1, 0, 0);
+	*///?}
 
 	@Shadow private float xRot;
 	@Shadow private float yRot;
@@ -181,13 +187,18 @@ public abstract class CameraMixin {
 
 		var quat = rotation();
 		//? if >=1.19.3 {
-		quat.rotateAxis(yaw * MathUtils.DEG_TO_RAD, 0, -1, 0);
+		quat.premul(new Quaternionf().rotationAxis(yaw * MathUtils.DEG_TO_RAD, 0, -1, 0));
+		//? if >=1.21.11
 		quat.rotateAxis(pitch * MathUtils.DEG_TO_RAD, -1, 0, 0);
+		//? if <1.21.11
+		/*quat.rotateAxis(pitch * MathUtils.DEG_TO_RAD, 1, 0, 0);*/
 		FORWARDS.rotate(quat, forwards);
 		UP.rotate(quat, up);
 		LEFT.rotate(quat, left);
 		//?} else {
-		/*quat.mul(com.mojang.math.Vector3f.YP.rotationDegrees(-yaw));
+		/*var yawQuat = com.mojang.math.Vector3f.YP.rotationDegrees(-yaw);
+		yawQuat.mul(quat);
+		quat.set(yawQuat.i(), yawQuat.j(), yawQuat.k(), yawQuat.r());
 		quat.mul(com.mojang.math.Vector3f.XP.rotationDegrees(-pitch));
 		forwards.set(0, 0, 1);
         forwards.transform(quat);


### PR DESCRIPTION
Tested 26.1.2, 1.20.6, 1.14.4.
Fixed third person on 1.20.6 (at least).
Commit d86a858 caused camera smoothing to "smooth" on the wrong axes.
Still doesn't use setRotation.
Fixes #115. Fixes #113.